### PR TITLE
Oval Speaker Avatar Shape -> Circular

### DIFF
--- a/_layouts/interior.html
+++ b/_layouts/interior.html
@@ -10,7 +10,7 @@
     <div>
       <div class="container text-center">
         <div class="col-lg-6 col-sm-8 col-lg-offset-3 col-sm-offset-2">
-          <img src="{{ page.image }}" class="img-circle img-responsive" style="padding-top: 2em;">
+          <img src="{{ page.image }}" class="img-circle img-responsive speaker-avatar">
         </div>
       </div>
       <h3>{{ page.speaker }}</h3><hr><h2>{{ page.title }}</h2>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -313,7 +313,7 @@ span.highlight {
             }
         }
     }
-    
+
     @media(max-width:768px) {
         .portfolio-box-caption {
             opacity: 0.85;
@@ -423,4 +423,12 @@ li.previous{ background: #F05F40; list-style-type: none; height: 125px; padding:
     @media (min-width: 1200px) {
         display: none;
     }
+}
+
+//interior page
+img.speaker-avatar {
+  object-fit:cover;
+  width:300px;
+  height:300px;
+  margin:2em auto 0 auto;
 }


### PR DESCRIPTION
Using CSS object-fit and predefined width/height to square the image. It is as if you used a background image and then clipped part of the image, except only using CSS and the preexisting img tag, without having to make major changes to markup.

The dimensions can be played with, but I feel like 300x300 is safe.

Referencing #78 