### PR TITLE
Fixed syntax error on line 10 of blog.html layout

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -7,7 +7,7 @@
   {% include nav-internal.html %}
   <header style="position: fixed; z-index: -5;"></header>
   <article style="padding-top: 50px;" class="container-fluid">
-		{% assign sorted = (site.blog | sort: 'date') | reverse %}
+		{% assign sorted = site.blog | sort: 'date' | reverse %}
      	{% for blog in sorted %}
         {% if blog.published == false %}
           {% continue %}


### PR DESCRIPTION
I saw whenever you served the site it threw an error on line 10 of _layouts/blog.html

I found this issue post on github and used it to fix the problem: https://github.com/Shopify/liquid/issues/917